### PR TITLE
Add help text for JLPT N2 option when Japanese university is selected

### DIFF
--- a/calc.js
+++ b/calc.js
@@ -86,6 +86,7 @@ function toggleSMECheckbox() {
 // Toggle JLPT N2 button based on japanese university degree
 const japaneseUniversityCheckbox = document.getElementById('japanese-university');
 const jlptN2Radio = document.getElementById('jlpt-n2');
+const jlptN2Help = document.getElementById('jlpt-n2-help');
 
 japaneseUniversityCheckbox.addEventListener('change', toggleJLPTN2Radio);
 
@@ -93,8 +94,10 @@ function toggleJLPTN2Radio() {
     if (japaneseUniversityCheckbox.checked) {
         jlptN2Radio.disabled = true;
         jlptN2Radio.checked = false;
+        jlptN2Help.style.display = 'block';
     } else {
         jlptN2Radio.disabled = false;
+        jlptN2Help.style.display = 'none';
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -136,6 +136,9 @@
                     <label for="jlpt-n2" class="checkbox-label">Passed N2 of the Japanese-Language Proficiency Test or
                         equivalent (e.g., 400+ points on the BJT), but not applicable if the applicant graduated from a
                         Japanese university</label>
+                    <div id="jlpt-n2-help" class="help-text" style="display: none;">
+                        <strong>Note:</strong> This option is not available because you selected "Graduated from a Japanese university" above. According to the regulations, JLPT N2 points cannot be claimed if you graduated from a Japanese university.
+                    </div>
                 </div>
                 <div>
                     <input type="radio" id="jlpt-none" name="japanese-proficiency" value="0">

--- a/style.css
+++ b/style.css
@@ -217,3 +217,20 @@ input:checked+.toggle-slider:before {
     margin-top: 20px;
     text-align: center;
 }
+
+.help-text {
+    margin-top: 10px;
+    margin-left: 20px;
+    padding: 12px;
+    background-color: #fff3cd;
+    border-left: 4px solid #ffc107;
+    border-radius: 4px;
+    font-size: 14px;
+    color: #856404;
+}
+
+.dark-mode .help-text {
+    background-color: #664d03;
+    border-left: 4px solid #ffc107;
+    color: #ffecb5;
+}


### PR DESCRIPTION
This change addresses issue #2 by adding a visible help text that appears when users select "Graduated from a Japanese university", explaining why the JLPT N2 option is disabled.

Changes:
- Added help text div in HTML next to JLPT N2 option
- Updated JavaScript to show/hide help text dynamically
- Added CSS styling for help text with warning-style appearance
- Included dark mode support for the help text