### PR TITLE
Fix dark mode contrast for footer disclaimer text

### DIFF
--- a/style.css
+++ b/style.css
@@ -234,3 +234,23 @@ input:checked+.toggle-slider:before {
     border-left: 4px solid #ffc107;
     color: #ffecb5;
 }
+
+.dark-mode footer {
+    color: #ccc;
+}
+
+.dark-mode .disclaimer {
+    color: #ccc;
+}
+
+.dark-mode .hosted-by {
+    color: #ccc;
+}
+
+.dark-mode footer a {
+    color: #66b3ff;
+}
+
+.dark-mode footer a:hover {
+    color: #99ccff;
+}


### PR DESCRIPTION
Improved readability of footer disclaimer and "Hosted by" text in dark mode by changing text color from #777 to #ccc and adding readable link colors (#66b3ff) for better contrast on dark backgrounds.

Fixes visibility issue where footer text was difficult to read in dark mode.