### PR TITLE
Improve theme readability with GitHub Primer colors

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,8 +1,8 @@
 body {
-    font-family: Arial, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
     line-height: 1.6;
-    color: #333;
-    background-color: #f4f4f4;
+    color: #24292f;
+    background-color: #ffffff;
     background-image: url('img/bg-light3.jpg');
     background-repeat: no-repeat;
     background-size: cover;
@@ -10,8 +10,8 @@ body {
 }
 
 .dark-mode {
-    background-color: #333;
-    color: #f4f4f4;
+    background-color: #0d1117;
+    color: #e6edf3;
     background-image: url('img/bg-dark3.jpg');
 }
 
@@ -27,11 +27,21 @@ h2 {
 }
 
 section {
-    background-color: #fff;
+    background-color: #ffffff;
     padding: 20px;
     margin-bottom: 20px;
-    border-radius: 5px;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+    border-radius: 6px;
+    border: 1px solid #d0d7de;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+a {
+    color: #0969da;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
 }
 
 label {
@@ -43,56 +53,72 @@ button {
     display: block;
     width: 100%;
     padding: 10px;
-    background-color: #007BFF;
-    color: #fff;
+    background-color: #1f883d;
+    color: #ffffff;
     font-size: 16px;
     border: none;
-    border-radius: 5px;
+    border-radius: 6px;
     cursor: pointer;
     margin-top: 20px;
+}
+
+button:hover {
+    background-color: #1a7f37;
 }
 
 footer {
     text-align: center;
     margin-top: 20px;
-    color: #777;
-}
-
-.dark-mode {
-    background-color: #333;
-    color: #f4f4f4;
+    color: #57606a;
 }
 
 .dark-mode section {
-    background-color: #444;
-    color: #f4f4f4;
+    background-color: #161b22;
+    color: #e6edf3;
+    border: 1px solid #30363d;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.dark-mode a {
+    color: #58a6ff;
+}
+
+.dark-mode a:hover {
+    color: #79c0ff;
 }
 
 .dark-mode button {
-    background-color: #007BFF;
-    color: #fff;
+    background-color: #238636;
+    color: #ffffff;
+}
+
+.dark-mode button:hover {
+    background-color: #2ea043;
 }
 
 .dark-mode .floating-points {
-    background-color: #444;
-    color: #f4f4f4;
+    background-color: #161b22;
+    color: #e6edf3;
+    border: 1px solid #30363d;
 }
 
 .section-title {
-    background-color: #f0f0f0;
+    background-color: #f6f8fa;
     padding: 10px;
-    border-radius: 5px 5px 0 0;
+    border-radius: 6px 6px 0 0;
     margin-bottom: 10px;
+    border-bottom: 1px solid #d0d7de;
 }
 
 .dark-mode .section-title {
-    background-color: #555;
+    background-color: #21262d;
+    border-bottom: 1px solid #30363d;
 }
 
 .disclaimer {
     margin-top: 40px;
     font-size: 14px;
-    color: #777;
+    color: #57606a;
 }
 
 .checkbox-label {
@@ -115,10 +141,11 @@ footer {
     align-items: center;
     justify-content: center;
     font-size: clamp(12px, 2vw, 40px);
-    background-color: #fff;
+    background-color: #ffffff;
+    border: 1px solid #d0d7de;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
     z-index: 100;
-    border-radius: 5px;
+    border-radius: 6px;
     cursor: move;
 }
 
@@ -222,35 +249,29 @@ input:checked+.toggle-slider:before {
     margin-top: 10px;
     margin-left: 20px;
     padding: 12px;
-    background-color: #fff3cd;
-    border-left: 4px solid #ffc107;
-    border-radius: 4px;
+    background-color: #fff8c5;
+    border: 1px solid #d4a72c;
+    border-left: 4px solid #bf8700;
+    border-radius: 6px;
     font-size: 14px;
-    color: #856404;
+    color: #4d2d00;
 }
 
 .dark-mode .help-text {
-    background-color: #664d03;
-    border-left: 4px solid #ffc107;
-    color: #ffecb5;
+    background-color: #3d2e00;
+    border: 1px solid #9e6a03;
+    border-left: 4px solid #d29922;
+    color: #f8e3a1;
 }
 
 .dark-mode footer {
-    color: #ccc;
+    color: #8b949e;
 }
 
 .dark-mode .disclaimer {
-    color: #ccc;
+    color: #8b949e;
 }
 
 .dark-mode .hosted-by {
-    color: #ccc;
-}
-
-.dark-mode footer a {
-    color: #66b3ff;
-}
-
-.dark-mode footer a:hover {
-    color: #99ccff;
+    color: #8b949e;
 }


### PR DESCRIPTION
- Fix hyperlink contrast issues in dark theme (#58a6ff)
- Update light theme to match GitHub's color palette
- Update dark theme backgrounds and text colors (#0d1117, #e6edf3)
- Improve button styling with GitHub green (#1f883d, #238636)
- Add proper borders and shadows to sections
- Update font family to GitHub's system font stack
- Ensure WCAG accessibility standards for color contrast

Resolves #10