### PR TITLE
Fix checkbox alignment for multi-line text

### DIFF
--- a/style.css
+++ b/style.css
@@ -121,10 +121,20 @@ footer {
     color: #57606a;
 }
 
+section > div {
+    display: flex;
+    align-items: flex-start;
+    margin-bottom: 10px;
+}
+
+input[type="checkbox"] {
+    margin-top: 3px;
+    flex-shrink: 0;
+}
+
 .checkbox-label {
     display: inline-block;
-    margin-left: 5px;
-    vertical-align: middle;
+    margin-left: 8px;
 }
 
 .sub-bullet {


### PR DESCRIPTION
- Added flexbox layout to section divs with align-items: flex-start
- Added margin-top to checkboxes for baseline alignment
- Added flex-shrink: 0 to prevent checkbox from shrinking
- Removed vertical-align: middle which doesn't work with multi-line text
- Increased checkbox label margin for better spacing

Fixes #12