### PR TITLE
feat: Add missing Bonus Points BP12, BP14, BP15

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ### Resources used:
 - [Points-Based-Immigration-Treatment, Govt of Japan](https://www.lb.emb-japan.go.jp/Points-Based-Immigration-Treatment.PDF)
 - [Ministry of Japan website](https://www.moj.go.jp/)
+- This calculator covers the bonus-point items applicable to the advanced specialized/technical activities (i)(b) track, excluding management-only items such as director-position and large-investment bonuses.
 
 Disclaimer: The host does not take any responsibility for the validity of the points. Please check the latest information on the [Ministry of Justice Japan webpage for highly-skilled human resources point system](https://www.moj.go.jp/isa/applications/resources/newimmiact_3_index.html)
 
@@ -19,5 +20,6 @@ Disclaimer: The host does not take any responsibility for the validity of the po
 ### 使用リソース：
 - [ポイント制外国人材処遇制度、日本政府](https://www.lb.emb-japan.go.jp/Points-Based-Immigration-Treatment.PDF)
 - [法務省ウェブサイト](https://www.moj.go.jp/)
+- この計算ツールは、高度専門・技術活動（i）（b）に適用されるボーナスポイント項目を対象としています。ただし、役員ポジションや大規模投資など経営・管理活動向けの項目は除きます。
 
 免責事項：ホストはポイントの有効性について一切責任を負いません。最新情報は[法務省高度人材ポイント制度ウェブサイト](https://www.moj.go.jp/isa/applications/resources/newimmiact_3_index.html)でご確認ください。

--- a/calc.js
+++ b/calc.js
@@ -13,6 +13,7 @@ var darkModeSwitch = document.getElementById('dark-mode-switch');
 var japaneseUniversityCheckbox = document.getElementById('japanese-university');
 var jlptN2Radio = document.getElementById('jlpt-n2');
 var jlptN2Help = document.getElementById('jlpt-n2-help');
+var designatedTrainingHelp = document.getElementById('designated-training-help');
 var progressMarker70 = document.getElementById('progress-marker-70');
 var progressMarker80 = document.getElementById('progress-marker-80');
 var progressMaxLabel = document.getElementById('progress-max-label');
@@ -31,6 +32,7 @@ form.addEventListener('change', calculatePoints);
 innovationSupportCheckbox.addEventListener('change', toggleSMECheckbox);
 resetButton.addEventListener('click', resetCalculator);
 japaneseUniversityCheckbox.addEventListener('change', toggleJLPTN2Radio);
+japaneseUniversityCheckbox.addEventListener('change', toggleDesignatedTrainingHelp);
 floatingPointsElement.addEventListener('mousedown', dragStart);
 document.addEventListener('mousemove', drag);
 document.addEventListener('mouseup', dragEnd);
@@ -145,6 +147,10 @@ function toggleJLPTN2Radio() {
     }
 }
 
+function toggleDesignatedTrainingHelp() {
+    designatedTrainingHelp.style.display = japaneseUniversityCheckbox.checked ? 'block' : 'none';
+}
+
 // ===== Progress Bar & Results =====
 /**
  * Updates the progress bar width and color based on current points.
@@ -219,6 +225,7 @@ function resetCalculator() {
     smeCheckbox.checked = false;
     jlptN2Radio.disabled = false;
     jlptN2Help.style.display = 'none';
+    designatedTrainingHelp.style.display = 'none';
     xOffset = 0;
     yOffset = 0;
     floatingPointsElement.style.transform = '';

--- a/index.html
+++ b/index.html
@@ -104,12 +104,19 @@
                     </div>
                     <div>
                         <input type="checkbox" id="highly-reputable" name="additional-academic" value="10">
-                        <label for="highly-reputable" class="checkbox-label">Graduated from a university that is recognized as "excellent" by the Ministry of Justice (<a href="https://kikuchi-immigration-services.com/blog/eligible-universities-for-hsp-highly-skilled-professionals-visa-in-japan/" target="_blank">see list</a>)</label>
+                        <label for="highly-reputable" class="checkbox-label">Graduated from a university that is recognized as "excellent" by the Ministry of Justice <sup><a href="#note-excellent-uni" aria-label="See explanation note 1">1</a></sup></label>
                     </div>
                     <div>
                         <input type="checkbox" id="multiple-degrees" name="additional-academic" value="5">
                         <label for="multiple-degrees" class="checkbox-label">Two or more doctoral or master's degrees or
                             professional degrees in multiple fields</label>
+                    </div>
+                    <div>
+                        <input type="checkbox" id="designated-training" name="additional-academic" value="5">
+                        <label for="designated-training" class="checkbox-label">Completed a training program designated by the Minister of Justice in a public notice (e.g., JICA Innovative Asia 1-year+ training) <sup><a href="#note-designated-training" aria-label="See explanation note 2">2</a></sup></label>
+                        <div id="designated-training-help" class="help-text" style="display: none;">
+                            <strong>Note:</strong> Per MoJ guidance, if this training was conducted using classes at a Japanese university or graduate school, it cannot be double-counted with points for graduating from a Japanese institution of higher education. Please verify whether this restriction applies to your training program.
+                        </div>
                     </div>
                 </fieldset>
             </section>
@@ -239,7 +246,15 @@
                     <div>
                         <input type="checkbox" id="foreign-qualification" name="additional-organization" value="5">
                         <label for="foreign-qualification" class="checkbox-label">Holding a foreign qualification related to
-                            the job (e.g., Attorney, AICPA, Fashion Awards, etc.)</label>
+                            the job (e.g., Attorney, AICPA, Fashion Awards, etc.) <sup><a href="#note-foreign-qualification" aria-label="See explanation note 3">3</a></sup></label>
+                    </div>
+                    <div>
+                        <input type="checkbox" id="investment-mgmt" name="additional-organization" value="10">
+                        <label for="investment-mgmt" class="checkbox-label">Engaged in work related to Investment Management Business, etc. <sup><a href="#note-investment-mgmt" aria-label="See explanation note 4">4</a></sup></label>
+                    </div>
+                    <div>
+                        <input type="checkbox" id="local-gov-target" name="additional-organization" value="10">
+                        <label for="local-gov-target" class="checkbox-label">Work for an MoJ-recognized target organization under local-government support measures for accepting highly skilled foreign workers <sup><a href="#note-local-gov-target" aria-label="See explanation note 5">5</a></sup></label>
                     </div>
                 </fieldset>
             </section>
@@ -309,17 +324,23 @@
         </section>
 
         <section id="explanation">
-            <h2>Explanation of Total Points</h2>
+            <h2>Explanation and Notes</h2>
             <ul>
                 <li>70 points path: To apply under the 3-year route, we must continuously maintain at least 70 points for the full 3 years immediately before the PR application date.</li>
                 <li>80 points path: To apply under the 1-year route, we must continuously maintain at least 80 points for the full 1 year immediately before the PR application date (for example, from D-1 year through D).</li>
                 <li>Please note that there are alternative paths to obtain permanent residency that do not require
                     points, such as completing a 10-year residency.</li>
-                <li>For foreign work-related qualification see: <a
-                        href="https://www.moj.go.jp/isa/content/930001661.pdf" target="_blank">List of foreign
-                        qualifications, awards, etc. that are eligible</a></li>
-                <li>For information about which universities are considered "excellent" by MoJ, see: <a
-                        href="https://kikuchi-immigration-services.com/blog/eligible-universities-for-hsp-highly-skilled-professionals-visa-in-japan/" target="_blank">Eligible Universities for HSP (Highly Skilled Professionals) Visa in Japan</a></li>
+                <li id="note-excellent-uni"><sup>1</sup> For information about which universities are considered "excellent" by MoJ, see: <a
+                        href="https://kikuchi-immigration-services.com/blog/eligible-universities-for-hsp-highly-skilled-professionals-visa-in-japan/" target="_blank">Eligible Universities for HSP (Highly Skilled Professionals) Visa in Japan</a>.</li>
+                <li id="note-designated-training"><sup>2</sup> Designated training means training specified by the Minister of Justice in a public notice; in practice this is qualifying training under the Ministry of Foreign Affairs' <a
+                        href="https://www.mofa.go.jp/mofaj/ic/ap_m/page22_002808.html" target="_blank">Innovative Asia program</a> (the reference target listed by MoJ for Bonus Point 12).</li>
+                <li id="note-foreign-qualification"><sup>3</sup> For foreign work-related qualification see: <a
+                        href="https://www.moj.go.jp/isa/content/930001661.pdf" target="_blank">List of foreign qualifications, awards, etc. that are eligible</a>.</li>
+                <li id="note-investment-mgmt"><sup>4</sup> Investment Management Business, etc. covers certain financial business categories such as Investment Management Business, Investment Advisory and Agency Business, and Type II Financial Instruments Business. See the <a
+                        href="https://www.moj.go.jp/isa/content/001398882.pdf" target="_blank">official MoJ points calculation table</a> and <a
+                        href="https://www.jetro.go.jp/en/invest/setting_up/section2/page11.html" target="_blank">JETRO's HSP overview</a>.</li>
+                <li id="note-local-gov-target"><sup>5</sup> Local-government target organizations are organizations supported under MoJ-recognized local-government measures for accepting highly skilled foreign professionals. See the <a
+                        href="https://www.moj.go.jp/isa/applications/resources/03_00068.html" target="_blank">MoJ page on local-government support measures for highly skilled foreign professionals</a>.</li>
             </ul>
         </section>
 

--- a/style.css
+++ b/style.css
@@ -121,13 +121,15 @@ footer {
     color: #57606a;
 }
 
-section > div {
+section > div,
+fieldset > div {
     display: flex;
     align-items: flex-start;
     margin-bottom: 10px;
 }
 
-input[type="checkbox"] {
+input[type="checkbox"],
+input[type="radio"] {
     margin-top: 3px;
     flex-shrink: 0;
 }


### PR DESCRIPTION

## Summary

Adds three bonus-point items from the [official MoJ Points Calculation Table](https://www.moj.go.jp/isa/content/001398882.pdf) that were missing from the specialist (i)(b) track calculator:

| Bonus Point | Description | Points |
|---|---|---|
| BP12 | Completion of MoJ-designated training (e.g., JICA Innovative Asia 1-year+ program) | +5 |
| BP14 | Engaged in work related to Investment Management Business, etc. | +10 |
| BP15 | Work for an MoJ-recognized target organization under local-government support measures | +10 |

## Changes

### index.html
- Added BP12 checkbox in "Additional Academic Qualifications" section with advisory help-text
- Added BP14 and BP15 checkboxes in "Additional Organization Points" section
- Added superscript reference markers (1-5) in document order linking form labels to explanation notes
- Restructured "Explanation and Notes" section with 5 numbered notes, each with anchor IDs and source links
- Removed redundant inline `(see list)` link from "highly-reputable" label (now covered by superscript note 1)
- Fixed BP12 link to point to MoFA Innovative Asia page (the URL MoJ itself references for BP12)

### calc.js
- Added DOM reference for `designated-training-help`
- Added `toggleDesignatedTrainingHelp()` function: shows advisory when Japanese-university is checked, hides when unchecked. Does NOT disable BP12.
- Extended `resetCalculator()` to clear the new help-text visibility

### style.css
- Fixed checkbox/radio label alignment: `section > div` selector didn't match `fieldset > div`, so long labels wrapped below the input instead of beside it. Added `fieldset > div` and extended `flex-shrink: 0` to radio inputs.

### README.md
- Added note that calculator covers specialist (i)(b) bonus points, excluding management-only items (BP2, BP13)

## What is NOT changing
- Salary-age matrix, age/academic/experience tables, 70/80 thresholds (verified against official PDF)
- BP2 (Director) and BP13 (100M investment): management-track only, intentionally omitted
- BP11 (excellent university): already covered by existing `highly-reputable` checkbox

## BP12 / BP7 interaction
Per MoJ Note 6 and [MoJ Q&A](https://www.moj.go.jp/isa/applications/resources/newimmiact_3_qa.html): if the BP12 training was conducted using classes at a Japanese university or graduate school, it cannot be double-counted with BP7. The UI shows an advisory help-text when the Japanese-university checkbox is checked, but does NOT auto-disable BP12. The user decides whether the restriction applies to their specific program.

## Verified links
All 7 external links return 200 and point to the correct content:
- kikuchi-immigration-services.com (eligible universities)
- moj.go.jp/isa/applications/resources/newimmiact_3_index.html (main HSP page)
- moj.go.jp/isa/content/001398882.pdf (official points table, English)
- moj.go.jp/isa/content/930001661.pdf (foreign qualifications list)
- moj.go.jp/isa/applications/resources/03_00068.html (local-government BP15 measures)
- jetro.go.jp/en/invest/setting_up/section2/page11.html (JETRO HSP overview, confirms BP14)
- mofa.go.jp/mofaj/ic/ap_m/page22_002808.html (MoFA Innovative Asia, BP12 reference)

## Testing
Browser tests (34 assertions) verified:
- BP12 +5, BP14 +10, BP15 +10 individually
- BP4 + BP15 work independently (+20)
- All three combined (+25)
- 50-point profile reaches 75 with new BPs, flips to 3-year route message
- Help-text toggle on Japanese-university without disabling BP12
- JLPT N2 conditional still works
- SME conditional still works
- Salary-age matrix unchanged
- Reset clears all new state
- All 5 superscript anchor targets exist

## Bonus Point coverage checklist (specialist (i)(b) track)
- [x] BP1: Age
- [x] BP3: Academic background
- [x] BP4: Innovation support organization
- [x] BP5: SME
- [x] BP6: R&D ratio >3%
- [x] BP7: Japanese university
- [x] BP8: JLPT N1/N2
- [x] BP9: Research achievements
- [x] BP10: Cutting-edge growth field
- [x] BP11: Excellent university (highly-reputable)
- [x] BP12: Designated MoJ training (NEW)
- [x] BP14: Investment Management Business (NEW)
- [x] BP15: Local-government target organization (NEW)
- [ ] BP2: Director position (management-only, intentionally omitted)
- [ ] BP13: 100M investment (management-only, intentionally omitted)
