### PR TITLE
chore: auto-mirror repo to japan-hsp-pr-points-calculator

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,29 @@
+name: Mirror to japan-hsp-pr-points-calculator
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: mirror
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source with full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push main to mirror
+        run: |
+          git push --force \
+            "https://x-access-token:${MIRROR_TOKEN}@github.com/rbnhd/japan-hsp-pr-points-calculator.git" \
+            main:main
+        env:
+          MIRROR_TOKEN: ${{ secrets.MIRROR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # Japan Permanent Residency Point Calculator
 
+**Live site:** https://rbnhd.github.io/pr-point-calc-japan/ (canonical) · https://rbnhd.github.io/japan-hsp-pr-points-calculator/ (mirror)
+
+> This repo is auto-mirrored to https://github.com/rbnhd/japan-hsp-pr-points-calculator for HSP-keyword discoverability on GitHub. Both Pages URLs serve the same calculator; the first is the canonical SEO target. Edit only this repo — the mirror is overwritten on every push to `main`.
+
 ### This calculator is designed for highly-skilled foreign professionals seeking permanent residency in Japan. Please note that there are alternative paths to obtain permanent residency that do not require points.
 
 ### Resources used:


### PR DESCRIPTION
Adds a GitHub Actions workflow that force-pushes main to a sibling repo on every push, plus a README note pointing to both Pages URLs. The mirror exists so people searching GitHub for "HSP" / "highly skilled professional" find the project too. Canonical URL on the served HTML keeps pointing to this repo so Google consolidates SEO signals here.

Auth: workflow uses a fine-grained PAT (MIRROR_TOKEN secret) scoped read+write only to the mirror repo.