### PR TITLE
fix(mirror): disable persist-credentials so MIRROR_TOKEN is actually used

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -19,6 +19,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Don't persist the default GITHUB_TOKEN as an extraheader in git
+          # config — otherwise it overrides the MIRROR_TOKEN we embed in the
+          # push URL below and the push fails with 403 "denied to
+          # github-actions[bot]".
+          persist-credentials: false
 
       - name: Push main to mirror
         run: |


### PR DESCRIPTION


actions/checkout@v4 defaults to writing the workflow's GITHUB_TOKEN into git's local config as an http.<github.com>.extraheader. That header is sent on every subsequent push to github.com and takes precedence over the token embedded in the push URL — so our MIRROR_TOKEN was being silently shadowed by the default github-actions[bot] token, which has no access to the mirror repo and was returning 403.

Setting persist-credentials: false stops checkout from writing that extraheader, allowing the URL-embedded MIRROR_TOKEN to be used.