### PR TITLE
fix(mirror): skip workflow when running on mirror repo

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -11,6 +11,13 @@ concurrency:
 
 jobs:
   mirror:
+    # Only run on the source repo — not on the mirror that inherits this file.
+    # When the mirror receives a force-push it will also trigger this workflow,
+    # but the if-check below causes it to skip immediately (green, no noise).
+    # This also lets us keep Actions enabled on the mirror so that GitHub's
+    # own "pages build and deployment" system workflow can rebuild Pages on
+    # every sync.
+    if: github.repository == 'rbnhd/pr-point-calc-japan'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Adds an if-condition so the mirror.yml job only executes on the source repo (pr-point-calc-japan). When the mirror inherits this file and a force-push triggers it, the job is skipped cleanly (green check, no noise or red Xs on the mirror's Actions tab).

This also means Actions can be re-enabled on the mirror, which is required for GitHub's own "pages build and deployment" system workflow to fire on each sync and keep the mirror's Pages site up to date.